### PR TITLE
Obtain foreground process name and add JSON parsing

### DIFF
--- a/CheatSheet.csproj
+++ b/CheatSheet.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.1.3" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 
@@ -34,7 +35,7 @@
     package has not yet been restored.
   -->
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
-    <ProjectCapability Include="Msix"/>
+    <ProjectCapability Include="Msix" />
   </ItemGroup>
 
   <!-- 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Microsoft.UI.Xaml.Shapes;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -18,9 +19,11 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Security;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json.Serialization;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
 using WinRT;
+using Path = System.IO.Path;
 
 namespace CheatSheet
 {
@@ -80,8 +83,10 @@ namespace CheatSheet
         {
             this.InitializeComponent();
 
+            // TODO: test code is here to be reused elsewhere
             var appName = GetActiveWindowProcessName();
             System.Console.WriteLine(appName);
+            PrintCommands(appName);
 
             m_wsdqHelper = new WindowsSystemDispatcherQueueHelper();
             m_wsdqHelper.EnsureWindowsSystemDispatcherQueueController();
@@ -223,6 +228,30 @@ namespace CheatSheet
             var filename = text.ToString().Split('\\')?.Last();
 
             return filename;
+        }
+
+        private void PrintCommands(string appName)
+        {
+            string json = ShortcutsData.Shortcuts;
+            var root = JsonConvert.DeserializeObject<ShortcutsJsonRoot>(json);
+
+            StringBuilder outputBuilder = new StringBuilder();
+            var appsArray = root.Apps;
+            foreach (var app in appsArray)
+            {
+                if (app.Name == appName)
+                {
+                    outputBuilder.AppendLine(app.FriendlyName + ":");
+                    foreach (var shortcut in app.Shortcuts)
+                    {
+                        outputBuilder.AppendLine("\t" + shortcut.Modifier + " + " + shortcut.Key + " : " + shortcut.Description);
+                    }
+                    break;
+                }
+            }
+
+            var output = outputBuilder.ToString();
+            System.Console.WriteLine(output);
         }
 
     }

--- a/Shortcuts.cs
+++ b/Shortcuts.cs
@@ -1,0 +1,37 @@
+﻿// Root myDeserializedClass = JsonConvert.DeserializeObject<Root>(myJsonResponse);
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+public class ShortcutsJsonRoot
+{
+    [JsonProperty("Apps")]
+    public List<App> Apps { get; set; }
+}
+
+public class App
+{
+    [JsonProperty("Name")]
+    public string Name { get; set; }
+
+    [JsonProperty("FriendlyName")]
+    public string FriendlyName { get; set; }
+
+    [JsonProperty("Shortcuts")]
+    public List<Shortcut> Shortcuts { get; set; }
+}
+
+public class Shortcut
+{
+    [JsonProperty("Modifier")]
+    public string Modifier { get; set; }
+
+    [JsonProperty("Key")]
+    public string Key { get; set; }
+
+    [JsonProperty("Description")]
+    public string Description { get; set; }
+
+    [JsonProperty("Extended")]
+    public string Extended { get; set; }
+}
+

--- a/ShortcutsData.cs
+++ b/ShortcutsData.cs
@@ -1,0 +1,75 @@
+﻿class ShortcutsData
+{
+    public static string Shortcuts = @"
+{
+  ""Apps"": [
+    {
+      ""Name"": ""notepad.exe"",
+      ""FriendlyName"": ""Notepad"",
+      ""Shortcuts"": [
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""C"",
+          ""Description"": ""Copy text"",
+          ""Extended"": ""Copy text to clipboard""
+        },
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""V"",
+          ""Description"": ""Paste text"",
+          ""Extended"": ""Paste text from clipboard""
+        },
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""X"",
+          ""Description"": ""Cut text"",
+          ""Extended"": ""Cut text to clipboard""
+        },
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""Z"",
+          ""Description"": ""Undo"",
+          ""Extended"": ""Undo last change""
+        }
+      ]
+    },
+    {
+      ""Name"": ""HxOutlook.exe"",
+      ""FriendlyName"": ""Mail"",
+      ""Shortcuts"": [
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""N"",
+          ""Description"": ""New mail"",
+          ""Extended"": ""Begin a new e-mail""
+        },
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""R"",
+          ""Description"": ""Reply"",
+          ""Extended"": ""Reply to the selected e-mail""
+        }
+      ]
+    },
+    {
+      ""Name"": ""devenv.exe"",
+      ""FriendlyName"": ""Visual Studio"",
+      ""Shortcuts"": [
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""O"",
+          ""Description"": ""Open file"",
+          ""Extended"": ""Open a file""
+        },
+        {
+          ""Modifier"": ""Ctrl"",
+          ""Key"": ""P"",
+          ""Description"": ""Go to file"",
+          ""Extended"": ""Go to a file""
+        }
+      ]
+    }
+  ]
+}
+";
+}


### PR DESCRIPTION
## Overview
Obtain the foreground application process name (e.g., "notepad.exe") and add JSON parsing for shortcut commands.

Add shortcuts JSON data to `ShrotcutsData.cs` and the corresponding classes in `Shortcuts.cs`.

## Testing

Obtains the appName and generates the comamnds list correctly:
![image](https://user-images.githubusercontent.com/7912381/191484211-869a543c-48c5-4632-abce-50d1ad7112d8.png)

![image](https://user-images.githubusercontent.com/7912381/191484289-a928c385-09e8-44f3-977c-8930874c4761.png)
